### PR TITLE
WIP: Use SVG's href to load svg icon instead of picture element

### DIFF
--- a/src/sidebar/view/SidebarListItemView.tsx
+++ b/src/sidebar/view/SidebarListItemView.tsx
@@ -42,11 +42,9 @@ function ListBaseItem(props: ListBaseItemProps): JSX.Element {
         <React.StrictMode>
             <PanelListItem disabled={isOpening}>
                 <PanelListItemIcon>
-                    <picture className={`${CLASS_NAME_PREFIX}__icon_img`}>
-                        <source srcSet={`${iconDir}dark/${iconFile}`} media={'(prefers-color-scheme: dark)'} />
-                        <source srcSet={`${iconDir}light/${iconFile}`} media={'(prefers-color-scheme: light)'} />
-                        <img alt={''} src={`${iconDir}context-fill/${iconFile}`} />
-                    </picture>
+                    <svg viewBox={'0 0 16 16'} width={'16'} height={'16'} className={`${CLASS_NAME_PREFIX}__icon_img`}>
+                        <use href={`${iconDir}context-fill/${iconFile}#icon`} />
+                    </svg>
                 </PanelListItemIcon>
                 <PanelListItemText>
                     {label}


### PR DESCRIPTION
* Dup with https://github.com/tetsuharuohzeki/linkplaces/pull/69
* By this change, we can use context-fill.