### PR TITLE
Revert "Use stable version of cats-oss/github-action-detect-unmergeable"

### DIFF
--- a/.github/workflows/detect_unmergeable_pull_request.yml
+++ b/.github/workflows/detect_unmergeable_pull_request.yml
@@ -22,6 +22,6 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "${GITHUB_CONTEXT}"
       - name: Run the action to detect unmergeable PRs
-        uses: cats-oss/github-action-detect-unmergeable@v2.1.1
+        uses: cats-oss/github-action-detect-unmergeable@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 0a07b0cafa1516d4856fa7f4974b692340ca9452.
That change does not improve to start up time for the action
dramatically. I think it's nice to use the latest as dogfooding.