### PR TITLE
Fix the bug that sidebar does not render anything in development build

### DIFF
--- a/src/shared/ix/filter.ts
+++ b/src/shared/ix/filter.ts
@@ -1,19 +1,8 @@
 export type FilterFn<T> = (input: T) => boolean;
-export type AsyncFilterFn<T> = (input: T) => (boolean | Promise<boolean>);
 
 export function* filterForIterable<T>(iter: Iterable<T>, filter: FilterFn<T>): Iterator<T> {
     for (const item of iter) {
         const ok = filter(item);
-        if (!ok) {
-            continue;
-        }
-        yield item;
-    }
-}
-
-export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, filter: AsyncFilterFn<T>): AsyncIterator<T> {
-    for await (const item of iter) {
-        const ok: boolean = await filter(item);
         if (!ok) {
             continue;
         }

--- a/src/shared/ix/filter.ts
+++ b/src/shared/ix/filter.ts
@@ -1,7 +1,7 @@
 export type FilterFn<T> = (input: T) => boolean;
 export type AsyncFilterFn<T> = (input: T) => (boolean | Promise<boolean>);
 
-export function* filterForIterable<T>(iter: Iterable<T>, filter: FilterFn<T>): Iterable<T> {
+export function* filterForIterable<T>(iter: Iterable<T>, filter: FilterFn<T>): Iterator<T> {
     for (const item of iter) {
         const ok = filter(item);
         if (!ok) {
@@ -11,7 +11,7 @@ export function* filterForIterable<T>(iter: Iterable<T>, filter: FilterFn<T>): I
     }
 }
 
-export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, filter: AsyncFilterFn<T>): AsyncIterable<T> {
+export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, filter: AsyncFilterFn<T>): AsyncIterator<T> {
     for await (const item of iter) {
         const ok: boolean = await filter(item);
         if (!ok) {

--- a/src/shared/ix/filter.ts
+++ b/src/shared/ix/filter.ts
@@ -1,11 +1,38 @@
+import { IterableX } from './iterable_x';
+
 export type FilterFn<T> = (input: T) => boolean;
 
-export function* filterForIterable<T>(iter: Iterable<T>, filter: FilterFn<T>): Iterator<T> {
+class FilterIterable<T> extends IterableX<T> {
+    private _filter: FilterFn<T>;
+
+    constructor(source: Iterable<T>, filter: FilterFn<T>) {
+        super(source);
+        this._filter = filter;
+    }
+
+    [Symbol.iterator](): Iterator<T> {
+        const iter = generateForIterator(this._source, this._filter);
+        return iter;
+    }
+}
+
+function* generateForIterator<T>(
+    iter: Iterable<T>,
+    filter: FilterFn<T>
+): Iterator<T> {
     for (const item of iter) {
-        const ok = filter(item);
+        const ok: boolean = filter(item);
         if (!ok) {
             continue;
         }
         yield item;
     }
+}
+
+export function filterForIterable<T>(
+    source: Iterable<T>,
+    filter: FilterFn<T>
+): Iterable<T> {
+    const wrapper = new FilterIterable(source, filter);
+    return wrapper;
 }

--- a/src/shared/ix/filter_async.ts
+++ b/src/shared/ix/filter_async.ts
@@ -1,0 +1,11 @@
+export type AsyncFilterFn<T> = (input: T) => (boolean | Promise<boolean>);
+
+export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, filter: AsyncFilterFn<T>): AsyncIterator<T> {
+    for await (const item of iter) {
+        const ok: boolean = await filter(item);
+        if (!ok) {
+            continue;
+        }
+        yield item;
+    }
+}

--- a/src/shared/ix/filter_async.ts
+++ b/src/shared/ix/filter_async.ts
@@ -1,6 +1,25 @@
-export type AsyncFilterFn<T> = (input: T) => (boolean | Promise<boolean>);
+import { AsyncIterableX } from './iterable_x';
 
-export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, filter: AsyncFilterFn<T>): AsyncIterator<T> {
+export type AsyncFilterFn<T> = (input: T) => boolean | Promise<boolean>;
+
+class FilterAsyncIterable<T> extends AsyncIterableX<T> {
+    private _filter: AsyncFilterFn<T>;
+
+    constructor(source: AsyncIterable<T>, filter: AsyncFilterFn<T>) {
+        super(source);
+        this._filter = filter;
+    }
+
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+        const iter = generateAsyncForAsyncIterator(this._source, this._filter);
+        return iter;
+    }
+}
+
+async function* generateAsyncForAsyncIterator<T>(
+    iter: AsyncIterable<T>,
+    filter: AsyncFilterFn<T>
+): AsyncIterator<T> {
     for await (const item of iter) {
         const ok: boolean = await filter(item);
         if (!ok) {
@@ -8,4 +27,12 @@ export async function* filterAsyncForAsyncIterable<T>(iter: AsyncIterable<T>, fi
         }
         yield item;
     }
+}
+
+export function filterAsyncForAsyncIterable<T>(
+    source: AsyncIterable<T>,
+    filter: AsyncFilterFn<T>
+): AsyncIterable<T> {
+    const wrapper = new FilterAsyncIterable(source, filter);
+    return wrapper;
 }

--- a/src/shared/ix/iterable_x.ts
+++ b/src/shared/ix/iterable_x.ts
@@ -1,0 +1,15 @@
+export abstract class IterableX<TInput, TOutput = TInput> implements Iterable<TOutput> {
+    protected _source: Iterable<TInput>;
+    constructor(source: Iterable<TInput>) {
+        this._source = source;
+    }
+    abstract [Symbol.iterator](): Iterator<TOutput>;
+}
+
+export abstract class AsyncIterableX<TInput, TOutput = TInput> implements AsyncIterable<TOutput> {
+    protected _source: AsyncIterable<TInput>;
+    constructor(source: AsyncIterable<TInput>) {
+        this._source = source;
+    }
+    abstract [Symbol.asyncIterator](): AsyncIterator<TOutput>;
+}

--- a/src/shared/ix/map.ts
+++ b/src/shared/ix/map.ts
@@ -1,16 +1,8 @@
 export type MapFn<TInput, TOutput> = (input: TInput) => TOutput;
-export type AsyncMapFn<TInput, TOutput> = (input: TInput) => (TOutput | Promise<TOutput>);
 
 export function* mapForIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: MapFn<TInput, TOutput>): Iterator<TOutput> {
     for (const item of iter) {
         const result = transform(item);
-        yield result;
-    }
-}
-
-export async function* mapAsyncForAsyncIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: AsyncMapFn<TInput, TOutput>): AsyncIterator<TOutput> {
-    for await (const item of iter) {
-        const result: TOutput = await transform(item);
         yield result;
     }
 }

--- a/src/shared/ix/map.ts
+++ b/src/shared/ix/map.ts
@@ -1,8 +1,38 @@
-export type MapFn<TInput, TOutput> = (input: TInput) => TOutput;
+import { IterableX } from './iterable_x';
 
-export function* mapForIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: MapFn<TInput, TOutput>): Iterator<TOutput> {
+export type TransformFn<TInput, TOutput> = (input: TInput) => TOutput;
+
+class MapIterable<TInput, TOutput> extends IterableX<TInput, TOutput> {
+    private _transformer: TransformFn<TInput, TOutput>;
+
+    constructor(
+        source: Iterable<TInput>,
+        transformer: TransformFn<TInput, TOutput>
+    ) {
+        super(source);
+        this._transformer = transformer;
+    }
+
+    [Symbol.iterator](): Iterator<TOutput> {
+        const iter = generateMapIterator(this._source, this._transformer);
+        return iter;
+    }
+}
+
+function* generateMapIterator<TInput, TOutput>(
+    iter: Iterable<TInput>,
+    transformer: TransformFn<TInput, TOutput>
+): Iterator<TOutput> {
     for (const item of iter) {
-        const result = transform(item);
+        const result = transformer(item);
         yield result;
     }
+}
+
+export function mapForIterable<TInput, TOutput>(
+    source: Iterable<TInput>,
+    transformer: TransformFn<TInput, TOutput>
+): Iterable<TOutput> {
+    const wrapper = new MapIterable(source, transformer);
+    return wrapper;
 }

--- a/src/shared/ix/map.ts
+++ b/src/shared/ix/map.ts
@@ -1,14 +1,14 @@
 export type MapFn<TInput, TOutput> = (input: TInput) => TOutput;
 export type AsyncMapFn<TInput, TOutput> = (input: TInput) => (TOutput | Promise<TOutput>);
 
-export function* mapForIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: MapFn<TInput, TOutput>): Iterable<TOutput> {
+export function* mapForIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: MapFn<TInput, TOutput>): Iterator<TOutput> {
     for (const item of iter) {
         const result = transform(item);
         yield result;
     }
 }
 
-export async function* mapAsyncForAsyncIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: AsyncMapFn<TInput, TOutput>): AsyncIterable<TOutput> {
+export async function* mapAsyncForAsyncIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: AsyncMapFn<TInput, TOutput>): AsyncIterator<TOutput> {
     for await (const item of iter) {
         const result: TOutput = await transform(item);
         yield result;

--- a/src/shared/ix/map_async.ts
+++ b/src/shared/ix/map_async.ts
@@ -1,8 +1,38 @@
-export type AsyncMapFn<TInput, TOutput> = (input: TInput) => (TOutput | Promise<TOutput>);
+import { AsyncIterableX } from './iterable_x';
 
-export async function* mapAsyncForAsyncIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: AsyncMapFn<TInput, TOutput>): AsyncIterator<TOutput> {
+export type AsyncTransformFn<TInput, TOutput> = (input: TInput) => TOutput | Promise<TOutput>;
+
+class MapAsyncIterable<TInput, TOutput> extends AsyncIterableX<TInput, TOutput> {
+    private _transformer: AsyncTransformFn<TInput, TOutput>;
+
+    constructor(
+        source: AsyncIterable<TInput>,
+        transformer: AsyncTransformFn<TInput, TOutput>
+    ) {
+        super(source);
+        this._transformer = transformer;
+    }
+
+    [Symbol.asyncIterator](): AsyncIterator<TOutput> {
+        const iter = generateMapAsyncIterator(this._source, this._transformer);
+        return iter;
+    }
+}
+
+async function* generateMapAsyncIterator<TInput, TOutput>(
+    iter: AsyncIterable<TInput>,
+    transform: AsyncTransformFn<TInput, TOutput>
+): AsyncIterator<TOutput> {
     for await (const item of iter) {
         const result: TOutput = await transform(item);
         yield result;
     }
+}
+
+export function mapAsyncForAsyncIterable<TInput, TOutput>(
+    source: AsyncIterable<TInput>,
+    transformer: AsyncTransformFn<TInput, TOutput>
+): AsyncIterable<TOutput> {
+    const wrapper = new MapAsyncIterable(source, transformer);
+    return wrapper;
 }

--- a/src/shared/ix/map_async.ts
+++ b/src/shared/ix/map_async.ts
@@ -1,0 +1,8 @@
+export type AsyncMapFn<TInput, TOutput> = (input: TInput) => (TOutput | Promise<TOutput>);
+
+export async function* mapAsyncForAsyncIterable<TInput, TOutput>(iter: Iterable<TInput>, transform: AsyncMapFn<TInput, TOutput>): AsyncIterator<TOutput> {
+    for await (const item of iter) {
+        const result: TOutput = await transform(item);
+        yield result;
+    }
+}

--- a/src/shared/ix/mod.ts
+++ b/src/shared/ix/mod.ts
@@ -1,12 +1,6 @@
-export {
-    filterForIterable as filter,
-    filterAsyncForAsyncIterable as filterAsync,
-} from './filter';
-export {
-    mapForIterable as map,
-    mapAsyncForAsyncIterable as mapAsync,
-} from './map';
-export {
-    toArrayFromIterable as toArray,
-    toArrayAsyncFromAsyncIterable as toArrayAsync,
-} from './toArray';
+export { filterForIterable as filter } from './filter';
+export { filterAsyncForAsyncIterable as filterAsync } from './filter_async';
+export { mapForIterable as map } from './map';
+export { mapAsyncForAsyncIterable as mapAsync } from './map_async';
+export { toArrayFromIterable as toArray } from './to_array';
+export { toArrayAsyncFromAsyncIterable as toArrayAsync } from './to_array_async';

--- a/src/shared/ix/toArray.ts
+++ b/src/shared/ix/toArray.ts
@@ -1,4 +1,6 @@
-export function toArrayFromIterable<T>(iter: Iterable<T>): Array<T> {
+type Consumable<T> = Iterable<T> | Generator<T>;
+
+export function toArrayFromIterable<T>(iter: Consumable<T>): Array<T> {
     const result: Array<T> = [];
     for (const item of iter) {
         result.push(item);
@@ -6,7 +8,9 @@ export function toArrayFromIterable<T>(iter: Iterable<T>): Array<T> {
     return result;
 }
 
-export async function toArrayAsyncFromAsyncIterable<T>(iter: AsyncIterable<T>): Promise<Array<T>> {
+type AsyncConsumable<T> = Iterable<T> | Generator<T>;
+
+export async function toArrayAsyncFromAsyncIterable<T>(iter: AsyncConsumable<T>): Promise<Array<T>> {
     const result: Array<T> = [];
     for await (const item of iter) {
         result.push(item);

--- a/src/shared/ix/to_array.ts
+++ b/src/shared/ix/to_array.ts
@@ -1,0 +1,11 @@
+type Consumable<T> = Iterable<T> | Generator<T>;
+
+export function toArrayFromIterable<T>(iter: Consumable<T>): Array<T> {
+    const result: Array<T> = [];
+    for (const item of iter) {
+        result.push(item);
+    }
+    return result;
+}
+
+

--- a/src/shared/ix/to_array_async.ts
+++ b/src/shared/ix/to_array_async.ts
@@ -1,13 +1,3 @@
-type Consumable<T> = Iterable<T> | Generator<T>;
-
-export function toArrayFromIterable<T>(iter: Consumable<T>): Array<T> {
-    const result: Array<T> = [];
-    for (const item of iter) {
-        result.push(item);
-    }
-    return result;
-}
-
 type AsyncConsumable<T> = Iterable<T> | Generator<T>;
 
 export async function toArrayAsyncFromAsyncIterable<T>(iter: AsyncConsumable<T>): Promise<Array<T>> {


### PR DESCRIPTION
With React's Strict Mode, all iterable would be consumed twice, so React component should take iterable, not generator (iterator).

However, our previous implementations of Ix always return iterator. This is not compatible with strict mode.

So I fix them to return iterable properly.