### PR TITLE
Add eslint.config.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ typecheck: ## Check static typing integrity
 lint: eslint stylelint check_relationship_between_workspace_and_ts_pj_reference ## Run all lints.
 
 eslint: ## Run ESLint
-	$(NPM_BIN_DIR)/eslint --ext=$(ESLINT_TARGET_EXTENSION) $(CURDIR)
+	$(NPM_BIN_DIR)/eslint '$(CURDIR)/**/*.{$(ESLINT_TARGET_EXTENSION)}'
 
 eslint_fix: ## Run ESLint with --fix option
-	$(NPM_BIN_DIR)/eslint --ext=$(ESLINT_TARGET_EXTENSION) $(CURDIR) --fix
+	$(NPM_BIN_DIR)/eslint '$(CURDIR)/**/*.{$(ESLINT_TARGET_EXTENSION)}' --fix
 
 stylelint: ## Run stylelint
 	$(NPM_BIN_DIR)/stylelint '$(CURDIR)/**/*.css' \

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { config as coreConfig } from './tools/eslint/new_config/core.js';
+import {
+    languageOptionsForModule,
+    languageOptionsForCommonJS,
+    languageOptionsForTesting,
+} from './tools/eslint/new_config/language_options.js';
+import { linterOptions } from './tools/eslint/new_config/linter_options.js';
+import {
+    createlanguageOptionsForTypeScript,
+    config as configForTypeScript,
+} from './tools/eslint/new_config/typescript.js';
+
+const THIS_FILE_NAME = fileURLToPath(import.meta.url);
+const THIS_DIR_NAME = path.dirname(THIS_FILE_NAME);
+
+// eslint-disable-next-line import/no-anonymous-default-export, import/no-default-export -- ESLint requires default export.
+export default [
+    'eslint:recommended',
+    coreConfig,
+    {
+        linterOptions,
+    },
+    {
+        ignores: [
+            // @prettier-ignore
+            '**/__dist/**/*',
+            '**/__obj/**/*',
+            '**/__plain/**/*',
+        ],
+    },
+    {
+        files: ['**/*.mjs', '**/*.js'],
+        languageOptions: languageOptionsForModule,
+    },
+    {
+        files: ['**/*.cjs'],
+        languageOptions: languageOptionsForCommonJS,
+    },
+    {
+        files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+        languageOptions: createlanguageOptionsForTypeScript(THIS_DIR_NAME),
+        ...configForTypeScript,
+    },
+    {
+        files: ['packages/webext_types/src/**/*.ts'],
+        rules: {
+            // These typings are not parts of this project.
+            '@typescript-eslint/naming-convention': 'off',
+        },
+    },
+    {
+        files: ['**/__tests__/*'],
+        ignores: ['**/.eslintrc.cjs'],
+        languageOptions: languageOptionsForTesting,
+        rules: {
+            // FIXME: This should be enabled.
+            'import/no-unresolved': 'off',
+        },
+    },
+];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-react": "7.31.11",
         "eslint-plugin-react-hooks": "4.6.0",
+        "globals": "^13.18.0",
         "prettier": "2.8.0",
         "stylelint": "14.16.0",
         "stylelint-config-prettier": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ importers:
       eslint-plugin-import: 2.26.0
       eslint-plugin-react: 7.31.11
       eslint-plugin-react-hooks: 4.6.0
+      globals: ^13.18.0
       prettier: 2.8.0
       stylelint: 14.16.0
       stylelint-config-prettier: 9.0.4
@@ -33,6 +34,7 @@ importers:
       eslint-plugin-import: 2.26.0_i656iqvetrvx3ajhg4t6psfrl4
       eslint-plugin-react: 7.31.11_eslint@8.29.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.29.0
+      globals: 13.18.0
       prettier: 2.8.0
       stylelint: 14.16.0
       stylelint-config-prettier: 9.0.4_stylelint@14.16.0
@@ -523,7 +525,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.1
-      globals: 13.17.0
+      globals: 13.18.0
       ignore: 5.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -2665,7 +2667,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.17.0
+      globals: 13.18.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.1
       import-fresh: 3.3.0
@@ -2713,7 +2715,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.17.0
+      globals: 13.18.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       import-fresh: 3.3.0
@@ -3174,8 +3176,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /globals/13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
+  /globals/13.18.0:
+    resolution: {integrity: sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2

--- a/tools/eslint/new_config/core.js
+++ b/tools/eslint/new_config/core.js
@@ -1,0 +1,36 @@
+import importPlugin from 'eslint-plugin-import';
+
+import projectRules from '../project_rules.cjs';
+import corePresets from '../vendor/core.cjs';
+import importPresets from '../vendor/import.cjs';
+
+import { config as prettierRules } from './prettier.js';
+
+export const config = Object.freeze({
+    plugins: {
+        import: importPlugin,
+    },
+    rules: {
+        ...corePresets.rules,
+        ...importPresets.rules,
+        ...prettierRules.rules,
+        ...projectRules.rules,
+        'import/extensions': [
+            'error',
+            'always',
+            {
+                ignorePackages: true,
+            },
+        ],
+    },
+    settings: {
+        ...importPresets.settings,
+        'import/parsers': {
+            '@typescript-eslint/parser': [
+                ...['.ts', '.tsx', '.mts', '.cts'],
+                // We need to specify this due to avoid `Parse errors in imported module './prettier.js': parserPath is required!`
+                ...['.js', '.mjs', '.cjs'],
+            ],
+        },
+    },
+});

--- a/tools/eslint/new_config/language_options.js
+++ b/tools/eslint/new_config/language_options.js
@@ -1,0 +1,31 @@
+import globals from 'globals';
+
+import languageOptionMod from '../language_option.cjs';
+
+const { ecmaVersion } = languageOptionMod;
+
+export const languageOptionsForModule = Object.freeze({
+    ecmaVersion,
+    sourceType: 'module',
+    globals: {
+        ...globals.nodeBuiltin,
+    },
+});
+
+export const languageOptionsForCommonJS = Object.freeze({
+    ecmaVersion,
+    sourceType: 'commonjs',
+    globals: {
+        ...globals.node,
+        ...globals.commonjs,
+    },
+});
+
+export const languageOptionsForTesting = Object.freeze({
+    ecmaVersion,
+    sourceType: 'module',
+    globals: {
+        ...globals.nodeBuiltin,
+        ...globals.browser,
+    },
+});

--- a/tools/eslint/new_config/linter_options.js
+++ b/tools/eslint/new_config/linter_options.js
@@ -1,0 +1,7 @@
+import linterOptionsMod from '../liniter_option.cjs';
+
+const { reportUnusedDisableDirectives } = linterOptionsMod;
+
+export const linterOptions = Object.freeze({
+    reportUnusedDisableDirectives,
+});

--- a/tools/eslint/new_config/prettier.js
+++ b/tools/eslint/new_config/prettier.js
@@ -1,0 +1,9 @@
+import presets from 'eslint-config-prettier';
+import userConfig from '../prettier.cjs';
+
+export const config = Object.freeze({
+    rules: {
+        ...presets.rules,
+        ...userConfig.rules,
+    },
+});

--- a/tools/eslint/new_config/typescript.js
+++ b/tools/eslint/new_config/typescript.js
@@ -1,0 +1,56 @@
+import tsESLintPlugin from '@typescript-eslint/eslint-plugin';
+import tsESLintParser from '@typescript-eslint/parser';
+import reactESLintPlugin from 'eslint-plugin-react';
+import reactHooksESLintPlugin from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+
+import tsconfigMod from '../typescript.cjs';
+import tsPresets from '../vendor/typescript.cjs';
+import tsReactPresets from '../vendor/typescript_react.cjs';
+
+const { createParserOptions, globals: tsGlobals } = tsconfigMod;
+
+export function createlanguageOptionsForTypeScript(baseDir) {
+    const parserOptions = createParserOptions(baseDir);
+
+    return Object.freeze({
+        sourceType: 'module',
+        globals: {
+            ...globals.builtin,
+            ...globals.browser,
+            ...globals.webextensions,
+            ...tsGlobals,
+        },
+        parser: tsESLintParser,
+        parserOptions: {
+            project: parserOptions.project,
+            ecmaFeatures: parserOptions.ecmaFeatures,
+            extraFileExtensions: parserOptions.extraFileExtensions,
+        },
+    });
+}
+
+export const config = Object.freeze({
+    plugins: {
+        '@typescript-eslint': tsESLintPlugin,
+        react: reactESLintPlugin,
+        'react-hooks': reactHooksESLintPlugin,
+    },
+    rules: {
+        ...reactHooksESLintPlugin.configs.recommended.rules,
+        ...tsPresets.rules,
+        ...tsReactPresets.rules,
+        ...tsconfigMod.rules,
+
+        'import/extensions': [
+            'error',
+            'always',
+            {
+                ignorePackages: true,
+            },
+        ],
+
+        // Use TypeScript's checking instead.
+        'import/no-unresolved': 'off',
+    },
+});

--- a/tools/eslint/project_rules.cjs
+++ b/tools/eslint/project_rules.cjs
@@ -18,8 +18,6 @@ const rules = Object.freeze({
             ],
         },
     ],
-    // FIXME: Re-enable for the future.
-    'import/no-unresolved': 'off',
 });
 
 const rulesForESModule = Object.freeze({


### PR DESCRIPTION
1. By this change, `make eslint` uses [this new flat config](https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new).
2. vscode-eslint will continue to look `.eslintrc.cjs`.
   - They has an option to use "flat config", but it's an experimental feature and only in pre-release 2.3.0