### PR TITLE
rx: Simplify Completion_result

### DIFF
--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe/data_pass_through.test.ts
@@ -2,7 +2,6 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk } from '../../../../mod.js';
 import { TestObservable, TestSubscriber } from './__helpers__/mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
@@ -76,8 +75,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // setup
     const TEST_INPUT = [1, 2, 3, 4];
     const testTarget = new TestObservable<number>((destination) => {
-        destination.complete(createCompletionOk());
-        destination.complete(createCompletionOk());
+        destination.complete(null);
+        destination.complete(null);
 
         for (const i of TEST_INPUT) {
             if (i % 2 !== 0) {
@@ -101,7 +100,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 0);
     t.is(onError.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber } from '../../../../mod.js';
 
 import { TestObservable, TestSubscriber } from './__helpers__/mod.js';
 
@@ -36,7 +36,7 @@ test('the destination should not be called after cancelled the subscription', (t
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     passedSubscriber!.error(new Error());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    passedSubscriber!.complete(createCompletionOk());
+    passedSubscriber!.complete(null);
 
     // assert
     t.is(onUnsubscribe.callCount, 1, 'onUnsubscribe callcount');

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe/do_not_pass_to_closed_destination.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe/do_not_pass_to_closed_destination.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber } from '../../../../mod.js';
 
 import { TestObservable, TestSubscriber } from './__helpers__/mod.js';
 
@@ -35,7 +35,7 @@ test('if the passed destination calls its unsubscribe() after start subscribing,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     passedSubscriber!.error(new Error());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    passedSubscriber!.complete(createCompletionOk());
+    passedSubscriber!.complete(null);
 
     // assertion
     t.is(onNext.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe/shutdown_subscription_on_destination_throw.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Observer, type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Observer, Subscriber } from '../../../../mod.js';
 import { TestObservable } from './__helpers__/mod.js';
 
 const spiedReportError = tinyspy.spy();
@@ -104,8 +104,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     let passedSubscriber: Subscriber<number>;
     const testTarget = new TestObservable<number>((destination) => {
         passedSubscriber = destination;
-        destination.complete(createCompletionOk());
-        destination.complete(createCompletionOk());
+        destination.complete(null);
+        destination.complete(null);
     });
     const observer = {
         next: tinyspy.spy(),

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe/throw_in_onsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe/throw_in_onsubscribe.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber, } from '../../../../mod.js';
 
 import { TestObservable, TestSubscriber } from './__helpers__/mod.js';
 
@@ -34,7 +34,7 @@ test('should throw if onSubscribeFn throw`', (t) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     passedSubscriber!.error(new Error());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    passedSubscriber!.complete(createCompletionOk());
+    passedSubscriber!.complete(null);
 
     // assert
     t.is(onSubscribeFn.callCount, 1);

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/data_pass_through.test.ts
@@ -2,7 +2,6 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk } from '../../../../mod.js';
 import { TestObservable } from './__helpers__/mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
@@ -79,8 +78,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // setup
     const TEST_INPUT = [1, 2, 3, 4];
     const testTarget = new TestObservable<number>((destination) => {
-        destination.complete(createCompletionOk());
-        destination.complete(createCompletionOk());
+        destination.complete(null);
+        destination.complete(null);
 
         for (const i of TEST_INPUT) {
             if (i % 2 !== 0) {
@@ -107,7 +106,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 0);
     t.is(onError.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber, } from '../../../../mod.js';
 
 import { TestObservable } from './__helpers__/mod.js';
 
@@ -38,7 +38,7 @@ test('the destination should not be called after cancelled the subscription', (t
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     passedSubscriber!.error(new Error());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    passedSubscriber!.complete(createCompletionOk());
+    passedSubscriber!.complete(null);
 
     // assert
     t.is(onUnsubscribe.callCount, 1, 'onUnsubscribe callcount');

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber, } from '../../../../mod.js';
 import { TestObservable } from './__helpers__/mod.js';
 
 const spiedReportError = tinyspy.spy();
@@ -108,8 +108,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     let passedSubscriber: Subscriber<number>;
     const testTarget = new TestObservable<number>((destination) => {
         passedSubscriber = destination;
-        destination.complete(createCompletionOk());
-        destination.complete(createCompletionOk());
+        destination.complete(null);
+        destination.complete(null);
     });
     const onNext = tinyspy.spy();
     const onError = tinyspy.spy();

--- a/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/throw_in_onsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/observable/subscribe_by/throw_in_onsubscribe.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Subscriber, createCompletionOk } from '../../../../mod.js';
+import type { Subscriber, } from '../../../../mod.js';
 
 import { TestObservable } from './__helpers__/mod.js';
 
@@ -42,7 +42,7 @@ test('should throw if onSubscribeFn throw`', (t) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     passedSubscriber!.error(new Error());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    passedSubscriber!.complete(createCompletionOk());
+    passedSubscriber!.complete(null);
 
     // assert
     t.is(onSubscribeFn.callCount, 1);

--- a/packages/foundation/src/rx/__tests__/core/subject/complete.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/complete.test.ts
@@ -1,26 +1,22 @@
 import test from 'ava';
-import { createOk } from 'option-t/plain_result';
 import * as tinyspy from 'tinyspy';
 import { Subject } from '../../../mod.js';
 
 test('.complete() should propagate it to the child', (t) => {
-    const INPUT = createOk<void>(undefined);
-
     const target = new Subject<number>();
     const onCompleted = tinyspy.spy();
     target.asObservable().subscribeBy({
         onCompleted: onCompleted,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     t.is(target.isCompleted, true);
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls, [[INPUT]]);
+    t.deepEqual(onCompleted.calls, [[null]]);
 });
 
 test('.complete() should stop myself', (t) => {
-    const INPUT = createOk<void>(undefined);
     const NORMAL_INPUT = Math.random();
 
     const target = new Subject<number>();
@@ -31,11 +27,11 @@ test('.complete() should stop myself', (t) => {
         onCompleted: onCompleted,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     t.is(target.isCompleted, true);
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls, [[INPUT]]);
+    t.deepEqual(onCompleted.calls, [[null]]);
 
     target.next(NORMAL_INPUT);
     t.is(onNext.callCount, 0);
@@ -45,8 +41,6 @@ test('.complete() should flip its flag at the first on calling it', (t) => {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     t.plan(4);
 
-    const INPUT = createOk<void>(undefined);
-
     const target = new Subject<number>();
     const onCompleted = tinyspy.spy(() => {
         t.is(target.isCompleted, true);
@@ -55,16 +49,14 @@ test('.complete() should flip its flag at the first on calling it', (t) => {
         onCompleted: onCompleted,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     t.is(target.isCompleted, true);
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls, [[INPUT]]);
+    t.deepEqual(onCompleted.calls, [[null]]);
 });
 
 test('.complete() should propagate the passed value on reentrant case', (t) => {
-    const INPUT = createOk<void>(undefined);
-
     // arrange
     const target = new Subject<number>();
     const onInnerComplete = tinyspy.spy();
@@ -79,14 +71,14 @@ test('.complete() should propagate the passed value on reentrant case', (t) => {
         onCompleted: onOuterComplete,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     // assert
     t.is(target.isCompleted, true);
 
     t.is(onOuterComplete.callCount, 1);
-    t.deepEqual(onOuterComplete.calls, [[INPUT]]);
+    t.deepEqual(onOuterComplete.calls, [[null]]);
 
     t.is(onInnerComplete.callCount, 1);
-    t.deepEqual(onOuterComplete.calls, [[INPUT]]);
+    t.deepEqual(onOuterComplete.calls, [[null]]);
 });

--- a/packages/foundation/src/rx/__tests__/core/subject/is_completed.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/is_completed.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { Subject, createCompletionOk } from '../../../mod.js';
+import { Subject, } from '../../../mod.js';
 
 test('set .isCompleted on calling .unsubscribe()', (t) => {
     const actual = new Subject();
@@ -13,7 +13,7 @@ test('set .isCompleted on calling .complete()', (t) => {
     const actual = new Subject();
 
     {
-        const result = createCompletionOk();
+        const result = null;
         actual.complete(result);
     }
 

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe/data_pass_through.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { Subject, createCompletionOk } from '../../../../mod.js';
+import { Subject, } from '../../../../mod.js';
 import { TestSubscriber } from './__helpers__/mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
@@ -85,8 +85,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
 
     // act
     const unsubscriber = testTarget.asObservable().subscribe(observer);
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
     for (const i of TEST_INPUT) {
         if (i % 2 !== 0) {
             testTarget.error(i);
@@ -101,7 +101,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 0);
     t.is(onError.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk, Subject } from '../../../../mod.js';
+import { Subject } from '../../../../mod.js';
 import { TestSubscriber } from './__helpers__/mod.js';
 
 test('the destination should not be called after cancelled the subscription', (t) => {
@@ -23,7 +23,7 @@ test('the destination should not be called after cancelled the subscription', (t
 
     subject.next();
     subject.error(new Error());
-    subject.complete(createCompletionOk());
+    subject.complete(null);
 
     // assert
     t.is(onNext.callCount, 0, 'should not call next callback');

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe/do_not_pass_to_closed_destination.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe/do_not_pass_to_closed_destination.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk, Subject } from '../../../../mod.js';
+import {  Subject } from '../../../../mod.js';
 
 import { TestSubscriber } from './__helpers__/mod.js';
 
@@ -27,7 +27,7 @@ test('if the passed destination calls its unsubscribe() after start subscribing,
 
     testTarget.next();
     testTarget.error(new Error());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
 
     // assertion
     t.is(onNext.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe/shutdown_subscription_on_destination_throw.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Observer, createCompletionOk, Subject } from '../../../../mod.js';
+import { type Observer,  Subject } from '../../../../mod.js';
 
 const spiedReportError = tinyspy.spy();
 
@@ -103,8 +103,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.teardown(() => {
         subscription.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
 
     // assert
     t.is(observer.next.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/data_pass_through.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { Subject, createCompletionOk } from '../../../../mod.js';
+import { Subject,  } from '../../../../mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
     // setup
@@ -93,8 +93,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     t.teardown(() => {
         unsubscriber.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
     for (const i of TEST_INPUT) {
         if (i % 2 !== 0) {
             testTarget.error(i);
@@ -106,7 +106,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 0);
     t.is(onError.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk, Subject } from '../../../../mod.js';
+import {  Subject } from '../../../../mod.js';
 
 test('the destination should not be called after cancelled the subscription', (t) => {
     t.plan(5);
@@ -24,7 +24,7 @@ test('the destination should not be called after cancelled the subscription', (t
 
     subject.next();
     subject.error(new Error());
-    subject.complete(createCompletionOk());
+    subject.complete(null);
 
     // assert
     t.is(onNext.callCount, 0, 'should not call next callback');

--- a/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk, Subject } from '../../../../mod.js';
+import {  Subject } from '../../../../mod.js';
 
 const spiedReportError = tinyspy.spy();
 
@@ -112,8 +112,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.teardown(() => {
         subscription.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
 
     // assert
     t.is(onNext.callCount, 0);

--- a/packages/foundation/src/rx/__tests__/core/subject/unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/core/subject/unsubscribe.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { Subject, createCompletionOk } from '../../../mod.js';
+import { Subject, } from '../../../mod.js';
 
 test('.unsubscribe() should stop myself', (t) => {
     const sub = new Subject();
@@ -77,5 +77,5 @@ test('.unsubscribe() should emit the completion to children', (t) => {
     target.unsubscribe();
 
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls, [[createCompletionOk()]]);
+    t.deepEqual(onCompleted.calls, [[null]]);
 });

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/complete.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/complete.test.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { spy } from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../mod.js';
+import { BehaviorSubject, } from '../../../mod.js';
 
 test('.complete() should propagate it to the child', (t) => {
-    const INPUT = createCompletionOk();
+    const INPUT = null;
 
     const target = new BehaviorSubject<number>(0);
     const onCompleted = spy();
@@ -20,7 +20,7 @@ test('.complete() should propagate it to the child', (t) => {
 });
 
 test('.complete() should stop myself', (t) => {
-    const INPUT = createCompletionOk();
+    const INPUT = null;
     const INITIAL_INPUT = 0;
     const NORMAL_INPUT = Math.random();
 
@@ -50,8 +50,6 @@ test('.complete() should flip its flag at the first on calling it', (t) => {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     t.plan(4);
 
-    const INPUT = createCompletionOk();
-
     const target = new BehaviorSubject<number>(0);
     const onCompleted = spy(() => {
         t.is(target.isCompleted, true);
@@ -60,16 +58,14 @@ test('.complete() should flip its flag at the first on calling it', (t) => {
         onCompleted: onCompleted,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     t.is(target.isCompleted, true);
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls, [[INPUT]]);
+    t.deepEqual(onCompleted.calls, [[null]]);
 });
 
 test('.complete() should propagate the passed value on reentrant case', (t) => {
-    const INPUT = createCompletionOk();
-
     // arrange
     const target = new BehaviorSubject<number>(0);
     const onInnerComplete = spy();
@@ -84,14 +80,14 @@ test('.complete() should propagate the passed value on reentrant case', (t) => {
         onCompleted: onOuterComplete,
     });
 
-    target.complete(INPUT);
+    target.complete(null);
 
     // assert
     t.is(target.isCompleted, true);
 
     t.is(onOuterComplete.callCount, 1);
-    t.deepEqual(onOuterComplete.calls, [[INPUT]]);
+    t.deepEqual(onOuterComplete.calls, [[null]]);
 
     t.is(onInnerComplete.callCount, 1);
-    t.deepEqual(onInnerComplete.calls, [[INPUT]]);
+    t.deepEqual(onInnerComplete.calls, [[null]]);
 });

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/is_completed.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/is_completed.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import { createOk } from 'option-t/plain_result';
 import { BehaviorSubject } from '../../../mod.js';
 
 test('set .isCompleted on calling .unsubscribe()', (t) => {
@@ -13,7 +12,7 @@ test('set .isCompleted on calling .complete()', (t) => {
     const actual = new BehaviorSubject(0);
 
     {
-        const result = createOk(undefined);
+        const result = null;
         actual.complete(result);
     }
 

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/data_pass_through.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject, } from '../../../../mod.js';
 import { TestSubscriber } from './__helpers__/mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
@@ -98,8 +98,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
 
     // act
     const unsubscriber = testTarget.asObservable().subscribe(observer);
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
     for (const i of TEST_INPUT) {
         if (i % 2 !== 0) {
             testTarget.error(i);
@@ -114,7 +114,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 1);
     t.deepEqual(onNext.calls, [[INITIAL_VALUE]]);

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/destination_is_closed.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/destination_is_closed.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, SubscriptionError, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject, SubscriptionError } from '../../../../mod.js';
 import { TestSubscriber } from './__helpers__/mod.js';
 
 test('if the passed destination is closed', (t) => {
@@ -27,7 +27,7 @@ test('if the passed destination is closed', (t) => {
 
     testTarget.next(SECOND_VALUE);
     testTarget.error(new Error());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
 
     // assertion
     t.is(onNext.callCount, 0, 'should not call onNext');

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { createCompletionOk, BehaviorSubject } from '../../../../mod.js';
+import {  BehaviorSubject } from '../../../../mod.js';
 import { TestSubscriber } from './__helpers__/mod.js';
 
 test('the destination should not be called after cancelled the subscription', (t) => {
@@ -25,7 +25,7 @@ test('the destination should not be called after cancelled the subscription', (t
 
     subject.next(SECOND_VALUE);
     subject.error(new Error());
-    subject.complete(createCompletionOk());
+    subject.complete(null);
 
     // assert
     t.is(onNext.callCount, 1, 'should call next calback');

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/do_not_pass_to_closed_destination.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/do_not_pass_to_closed_destination.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject,  } from '../../../../mod.js';
 
 import { TestSubscriber } from './__helpers__/mod.js';
 
@@ -29,7 +29,7 @@ test('if the passed destination calls its unsubscribe() after start subscribing,
 
     testTarget.next(SECOND_VALUE);
     testTarget.error(new Error());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
 
     // assertion
     t.is(onNext.callCount, 1);

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe/shutdown_subscription_on_destination_throw.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { type Observer, createCompletionOk, BehaviorSubject } from '../../../../mod.js';
+import { type Observer,  BehaviorSubject } from '../../../../mod.js';
 
 const spiedReportError = tinyspy.spy();
 
@@ -114,8 +114,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.teardown(() => {
         subscription.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
 
     // assert
     t.is(observer.next.callCount, 1);
@@ -124,7 +124,7 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.is(observer.complete.callCount, 1);
     t.deepEqual(observer.complete.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.deepEqual(observer.complete.results, [['error', THROWN_ERROR]]);
 

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/data_pass_through.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/data_pass_through.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject, } from '../../../../mod.js';
 
 test('.subscribe() should propagate the passed value to the child: onNext()', (t) => {
     // setup
@@ -98,8 +98,8 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     t.teardown(() => {
         unsubscriber.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
     for (const i of TEST_INPUT) {
         if (i % 2 !== 0) {
             testTarget.error(i);
@@ -111,7 +111,7 @@ test('.subscribe() should propagate the passed value to the child: onCompleted',
     // assert
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.is(onNext.callCount, 1);
     t.deepEqual(onNext.calls, [

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/destination_should_stop_after_unsubscribe.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject, } from '../../../../mod.js';
 
 test('the destination should not be called after cancelled the subscription', (t) => {
     t.plan(6);
@@ -26,7 +26,7 @@ test('the destination should not be called after cancelled the subscription', (t
 
     subject.next(SECOND_VALUE);
     subject.error(new Error());
-    subject.complete(createCompletionOk());
+    subject.complete(null);
 
     // assert
     t.is(onNext.callCount, 1, 'should call next calback');

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/subscribe_by/shutdown_subscription_on_destination_throw.test.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as tinyspy from 'tinyspy';
 
-import { BehaviorSubject, createCompletionOk } from '../../../../mod.js';
+import { BehaviorSubject } from '../../../../mod.js';
 
 const spiedReportError = tinyspy.spy();
 
@@ -124,8 +124,8 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.teardown(() => {
         subscription.unsubscribe();
     });
-    testTarget.complete(createCompletionOk());
-    testTarget.complete(createCompletionOk());
+    testTarget.complete(null);
+    testTarget.complete(null);
 
     // assert
     t.is(onNext.callCount, 1);
@@ -137,7 +137,7 @@ test.serial('Graceful shutdown subscriptions if the child observer throw the err
     t.is(onCompleted.callCount, 1);
     t.deepEqual(onCompleted.calls, [
         // @prettier-ignore
-        [createCompletionOk()],
+        [null],
     ]);
     t.deepEqual(onCompleted.results, [['error', THROWN_ERROR]]);
 

--- a/packages/foundation/src/rx/__tests__/subjects/behavior_subject/unsubscribe.test.ts
+++ b/packages/foundation/src/rx/__tests__/subjects/behavior_subject/unsubscribe.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import { createOk } from 'option-t/plain_result';
 import * as tinyspy from 'tinyspy';
 
 import { Subject, BehaviorSubject, type CompletionResult } from '../../../mod.js';
@@ -85,5 +84,5 @@ test('.unsubscribe() should emit the completion to children', (t) => {
     target.unsubscribe();
 
     t.is(onCompleted.callCount, 1);
-    t.deepEqual(onCompleted.calls.at(0), [createOk(undefined)]);
+    t.deepEqual(onCompleted.calls.at(0), [null]);
 });

--- a/packages/foundation/src/rx/core/completion_result.ts
+++ b/packages/foundation/src/rx/core/completion_result.ts
@@ -1,9 +1,10 @@
-import { createErr, createOk, type Ok, type Result } from 'option-t/plain_result';
+import type { Nullable } from 'option-t/nullable';
 
-export type CompletionResult = Result<void, unknown>;
-
-export function createCompletionOk(): Ok<void> {
-    return createOk(undefined);
-}
-
-export const createCompletionErr: typeof createErr<unknown> = createErr<unknown>;
+// XXX:
+// We use this only on calling `.complete()` now, thus:
+//
+//  1. We don't pass an arbitrary sucess value.
+//  2. We don't pass an arbitrary error value that is not `Error` instance.
+//
+//  By these reasons, we stopped to use _result_ type here.
+export type CompletionResult = Nullable<Error>;

--- a/packages/foundation/src/rx/core/subscriber_impl.ts
+++ b/packages/foundation/src/rx/core/subscriber_impl.ts
@@ -1,4 +1,4 @@
-import { isNotNull, unwrapNullable, type Nullable } from 'option-t/nullable';
+import { isNotNull, isNull, unwrapNullable, type Nullable } from 'option-t/nullable';
 import type { CompletionResult } from './completion_result.js';
 import type { Observer } from './observer.js';
 import type { Unsubscribable } from './subscribable.js';
@@ -76,6 +76,16 @@ export abstract class InternalSubscriber<T> implements Subscriber<T>, Unsubscrib
     }
 
     complete(result: CompletionResult): void {
+        if (
+            !(
+                isNull(null) ||
+                // FIXME: This should be `Error.isError`
+                result instanceof Error
+            )
+        ) {
+            throw new TypeError('the passed result must be CompletionResult');
+        }
+
         if (this._isCalledOnCompleted) {
             return;
         }

--- a/packages/foundation/src/rx/core/subscription_error.ts
+++ b/packages/foundation/src/rx/core/subscription_error.ts
@@ -6,3 +6,9 @@ export class SubscriptionError extends Error {
         this.name = new.target.name;
     }
 }
+
+export class SubscriptionCompleteByFailureError extends SubscriptionError {
+    constructor(cause: unknown) {
+        super('The factory throws something and the subscription is stopped', cause);
+    }
+}

--- a/packages/foundation/src/rx/mod.ts
+++ b/packages/foundation/src/rx/mod.ts
@@ -1,4 +1,4 @@
-export { createCompletionErr, createCompletionOk, type CompletionResult } from './core/completion_result.js';
+export type { CompletionResult } from './core/completion_result.js';
 export { Observable, type OnSubscribeFn } from './core/observable.js';
 export type { Observer } from './core/observer.js';
 export { Subject } from './core/subject.js';

--- a/packages/foundation/src/rx/observables/create.ts
+++ b/packages/foundation/src/rx/observables/create.ts
@@ -1,6 +1,7 @@
-import { createCompletionErr, createCompletionOk, type CompletionResult } from '../core/completion_result.js';
+import type { CompletionResult } from '../core/completion_result.js';
 import { Observable } from '../core/observable.js';
 import type { Subscriber } from '../core/subscriber.js';
+import { SubscriptionCompleteByFailureError } from '../core/subscription_error.js';
 
 export type SyncFactoryFn<T> = (observer: Subscriber<T>, signal: AbortSignal) => void;
 
@@ -16,10 +17,10 @@ class SyncFactoryObservable<T> extends Observable<T> {
             let result: CompletionResult;
             try {
                 factory(destination, signal);
-                result = createCompletionOk();
+                result = null;
             } catch (e: unknown) {
                 destination.error(e);
-                result = createCompletionErr(e);
+                result = new SubscriptionCompleteByFailureError(e);
             }
             destination.complete(result);
         });

--- a/packages/foundation/src/rx/observables/create_async.ts
+++ b/packages/foundation/src/rx/observables/create_async.ts
@@ -1,6 +1,6 @@
-import { createCompletionErr, createCompletionOk } from '../core/completion_result.js';
 import { Observable } from '../core/observable.js';
 import type { Subscriber } from '../core/subscriber.js';
+import { SubscriptionCompleteByFailureError } from '../core/subscription_error.js';
 
 export type AsyncFactoryFn<T> = (observer: Subscriber<T>, signal: AbortSignal) => Promise<void>;
 
@@ -16,12 +16,11 @@ class AsyncFactoryObservable<T> extends Observable<T> {
             const promise = factory(destination, signal);
             promise.then(
                 () => {
-                    const ok = createCompletionOk();
-                    destination.complete(ok);
+                    destination.complete(null);
                 },
                 (e: unknown) => {
                     destination.error(e);
-                    const error = createCompletionErr(e);
+                    const error = new SubscriptionCompleteByFailureError(e);
                     destination.complete(error);
                 }
             );

--- a/packages/foundation/src/rx/observables/from_async_iterable.ts
+++ b/packages/foundation/src/rx/observables/from_async_iterable.ts
@@ -1,4 +1,3 @@
-import { createCompletionOk } from '../core/completion_result.js';
 import type { Observable } from '../core/observable.js';
 import type { Subscriber } from '../core/subscriber.js';
 import { createObservableFromAsync } from './create_async.js';
@@ -12,8 +11,7 @@ async function iterate<T>(factory: AsyncIterable<T>, destination: Subscriber<T>,
         destination.next(item);
     }
 
-    const ok = createCompletionOk();
-    destination.complete(ok);
+    destination.complete(null);
 }
 
 export function fromAsyncIterableToObservable<T>(factory: AsyncIterable<T>): Observable<T> {

--- a/packages/foundation/src/rx/observables/from_event.ts
+++ b/packages/foundation/src/rx/observables/from_event.ts
@@ -1,4 +1,3 @@
-import { createCompletionOk } from '../core/completion_result.js';
 import { Observable } from '../core/observable.js';
 import type { Subscriber } from '../core/subscriber.js';
 
@@ -10,8 +9,7 @@ class FromEventObservable extends Observable<Event> {
             destination.addTeardown(() => {
                 aborter.abort();
 
-                const ok = createCompletionOk();
-                destination.complete(ok);
+                destination.complete(null);
             });
 
             target.addEventListener(

--- a/packages/foundation/src/rx/operators/merge.ts
+++ b/packages/foundation/src/rx/operators/merge.ts
@@ -1,6 +1,5 @@
-import { isErr, isOk } from 'option-t/plain_result';
+import { isNull } from 'option-t/nullable';
 
-import { assertUnreachable } from '../../assert_never.js';
 import type { CompletionResult } from '../core/completion_result.js';
 import { Observable } from '../core/observable.js';
 import type { Subscriber } from '../core/subscriber.js';
@@ -31,16 +30,15 @@ class MergeSubscriber<T> extends InternalSubscriber<T> {
     }
 
     protected override onCompleted(result: CompletionResult): void {
-        if (isErr(result)) {
-            this._destination.complete(result);
-        } else if (isOk(result)) {
+        if (isNull(result)) {
             const currentLivings = this._decrementRef();
             if (currentLivings <= 0) {
                 this._destination.complete(result);
             }
-        } else {
-            assertUnreachable(result);
+            return;
         }
+
+        this._destination.complete(result);
     }
 }
 


### PR DESCRIPTION
We use this only on calling `.complete()` now, thus:

1. We don't pass an arbitrary sucess value.
2. We don't pass an arbitrary error value that is not `Error` instance.

By these reasons, we stopped to use _result_ type here.