### PR TITLE
ci: Use `$` syntax to specify in-repository github actions

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -18,7 +18,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
 
     build:
         timeout-minutes: 10 # This value is just by feeling.
@@ -35,7 +35,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
             - name: build
               run: make build_${{ matrix.variants }} -j
               env:
@@ -51,7 +51,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
             - name: Lint
               run: make lint -j
               env:
@@ -67,7 +67,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
             - name: typecheck
               run: make typecheck -j
               env:
@@ -83,7 +83,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
             - name: check formatting
               run: make format_check -j
               env:
@@ -99,7 +99,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/setup_ci
+            - uses: $/.github/actions/setup_ci
             - name: Run unittests
               run: make test -j
               env:

--- a/.github/workflows/ci_for_pr.yaml
+++ b/.github/workflows/ci_for_pr.yaml
@@ -13,4 +13,4 @@ concurrency:
 
 jobs:
     ci:
-        uses: ./.github/workflows/_ci.yaml
+        uses: $/.github/workflows/_ci.yaml

--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
     ci:
-        uses: ./.github/workflows/_ci.yaml
+        uses: $/.github/workflows/_ci.yaml


### PR DESCRIPTION
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow-at-the-running-commit-recommended
- https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/